### PR TITLE
Refactor: Integrate Ollama, add unified start scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,59 @@
 # General Purpose Agent
 
-A GUI-based general-purpose agent with features like checking for updates from GitHub and a chatbot interface using local language models.
+A GUI-based general-purpose agent with features like checking for updates from GitHub and a chatbot interface using a local Ollama instance.
 
 ## Current Features
 
 *   **Graphical User Interface:** Built with PyQt5, providing a user-friendly way to interact with the agent.
-*   **Update Functionality:**
-    *   A "Check for updates" button allows the agent to check a specified GitHub repository for new versions.
-    *   If updates are found, the agent can (conceptually) download them and restart.
-    *   The current update repository is set to: `https://github.com/onlyzerosonce/SigmaOne`
+*   **Automated Setup & Updates:** Start scripts (`start.bat` for Windows, `start.sh` for Linux/macOS) handle:
+    *   Checking and installing required Python libraries (`PyQt5`, `GitPython`, `requests`).
+    *   Checking for new versions of the agent from GitHub and automatically updating.
 *   **Chatbot Integration:**
-    *   A chat interface (display and input field) is provided.
-    *   The agent attempts to load a local language model (currently configured for `distilgpt2` from Hugging Face Transformers) to power the chatbot.
-    *   If the model or its dependencies are unavailable, the agent will indicate this in the chat window.
+    *   Connects to a local Ollama instance for AI responses.
+    *   Users need to have Ollama installed and a model (e.g., Llama2, etc.) pulled and running.
+    *   The agent attempts to connect to the default Ollama API endpoint (`http://localhost:11434`).
 
-## Setup and Installation
+## Prerequisites
 
-1.  **Prerequisites:**
-    *   Python 3.7+
-
-2.  **Clone the repository (if you haven't already):**
-    ```bash
-    git clone <your-repository-url>
-    cd <repository-directory>
-    ```
-
-3.  **Install required libraries:**
-    It's recommended to use a virtual environment.
-    ```bash
-    python -m venv venv
-    source venv/bin/activate  # On Windows use `venv\Scripts\activate`
-    pip install PyQt5 GitPython transformers torch
-    ```
+1.  **Python 3.7+:** Download from [https://www.python.org/](https://www.python.org/) and ensure it's added to your system's PATH.
+2.  **Git:** Required for the application to update itself. Download from [https://git-scm.com/](https://git-scm.com/).
+3.  **Ollama:** The chatbot functionality relies on Ollama.
+    *   Install Ollama from [https://ollama.com/](https://ollama.com/).
+    *   Ensure Ollama is running and you have pulled a model (e.g., `ollama pull llama2`).
 
 ## How to Run
 
-Once you have installed the dependencies, you can run the agent using:
+1.  **Clone the repository (if you haven't already):**
+    ```bash
+    git clone https://github.com/onlyzerosonce/SigmaOne # Or your fork's URL
+    cd SigmaOne
+    ```
+    *(Note: The start scripts can also perform the initial clone if run in an empty directory intended for the agent, but cloning first is clearer.)*
 
-```bash
-python main.py
-```
+2.  **Run the startup script:**
+    *   **For Windows:**
+        Navigate to the repository directory in Command Prompt or PowerShell and run:
+        ```bash
+        start.bat
+        ```
+    *   **For Linux/macOS:**
+        Open your terminal, navigate to the repository directory, make the script executable (if needed, though it should be set), and run:
+        ```bash
+        chmod +x start.sh # If not already executable
+        ./start.sh
+        ```
+
+3.  **Follow On-Screen Prompts:** The script will guide you through dependency checks, Ollama detection, updates, and then launch the agent.
 
 ## Known Issues and Limitations
 
-*   **Network Dependency for Updates:** The "Check for updates" feature requires an active internet connection and `GitPython` to be correctly installed and configured to interact with the GitHub repository.
-*   **Network Dependency for Chatbot Model:** The initial download of the chatbot language model (`distilgpt2` or other Hugging Face models) requires an active internet connection. Subsequent runs will use the cached model if available.
-*   **Chatbot Model Performance:** `distilgpt2` is a relatively small model. Its conversational abilities are limited. For more advanced chatbot performance, a larger model might be necessary, which would also increase resource requirements.
-*   **Update Restart Mechanism:** The application restart after an update is currently simulated by exiting the application. A more robust, platform-specific restart mechanism may be needed for production use.
-*   **Testing Environment:** Some features (notably Git operations and model downloads) could not be fully tested in the development sandbox due to network restrictions.
+*   **Ollama Dependency:** Chatbot functionality is entirely dependent on a correctly installed and running Ollama instance with a suitable model available. The agent does not install Ollama itself.
+*   **Network Dependency:** Initial download of Python packages and application updates requires an active internet connection.
+*   **Scripted Setup:** The startup scripts attempt to manage Python dependencies but might encounter issues on systems with complex Python environments or restrictive permissions.
+*   **Update Restart Mechanism:** The application restart after an update (if implemented by `main.py` itself) is currently simulated by exiting the application. The start script handles pulling changes before launch.
 
 ## Future Plans
-
-*   Enhance chatbot capabilities with more advanced models and tool usage.
+*   Allow user to specify Ollama model and endpoint via UI or config file.
+*   Enhance error reporting and recovery in start scripts.
+*   Improve the update mechanism within the application itself for a smoother experience post-update.
 *   Add more features to the agent as required.
-*   Improve the update mechanism.

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,124 @@
+@echo off
+setlocal
+
+REM --- Configuration ---
+set PYTHON_EXE=python
+set PIP_EXE=pip
+set REPO_URL="https://github.com/onlyzerosonce/SigmaOne"
+set LOCAL_REPO_PATH="."
+set OLLAMA_API_ENDPOINT="http://localhost:11434"
+set REQUIRED_PACKAGES=PyQt5 GitPython requests
+
+REM --- Helper function to check if a command exists ---
+:check_command
+where %1 >nul 2>nul
+if %errorlevel% equ 0 (
+    exit /b 0
+) else (
+    exit /b 1
+)
+
+REM --- 1. Check for Python ---
+echo Checking for Python...
+call :check_command %PYTHON_EXE%
+if %errorlevel% neq 0 (
+    echo Python is not found in PATH.
+    echo Please install Python from https://www.python.org/downloads/ and ensure it's added to your PATH.
+    goto :error_exit
+)
+echo Python found.
+
+REM --- 2. Check for Pip ---
+echo Checking for Pip...
+call :check_command %PIP_EXE%
+if %errorlevel% neq 0 (
+    echo Pip is not found.
+    echo Attempting to ensure pip is installed/updated with Python...
+    %PYTHON_EXE% -m ensurepip --upgrade
+    call :check_command %PIP_EXE%
+    if %errorlevel% neq 0 (
+      echo Failed to install Pip. Please ensure your Python installation is correct.
+      goto :error_exit
+    )
+)
+echo Pip found.
+
+REM --- 3. Install/Upgrade Python dependencies ---
+echo Checking and installing Python packages: %REQUIRED_PACKAGES%...
+for %%p in (%REQUIRED_PACKAGES%) do (
+    echo Installing/updating %%p...
+    %PIP_EXE% install --upgrade %%p
+    if errorlevel 1 (
+        echo Failed to install %%p. Please check your Python/pip setup and internet connection.
+        goto :error_exit
+    )
+)
+echo All required Python packages are installed/updated.
+
+REM --- 4. Check for Ollama ---
+echo Checking for Ollama service at %OLLAMA_API_ENDPOINT%...
+REM Using curl if available (common on modern Windows), otherwise a simple ping-like check for the port might be too complex for batch.
+REM For simplicity, we'll use powershell's Test-NetConnection if available, or just inform the user.
+powershell -Command "if (Test-NetConnection -ComputerName localhost -Port 11434 -WarningAction SilentlyContinue | Select-Object -ExpandProperty TcpTestSucceeded) { exit 0 } else { exit 1 }"
+if errorlevel 1 (
+    echo Ollama service not detected at %OLLAMA_API_ENDPOINT%.
+    echo Please ensure Ollama is installed and running.
+    echo You can download Ollama from https://ollama.com/
+    echo The agent may not function correctly without Ollama.
+    echo Continuing to start the agent, but chatbot features will likely be disabled.
+    echo.
+) else (
+    echo Ollama service detected.
+)
+
+
+REM --- 5. Git Repository Update ---
+echo Checking for application updates...
+if not exist "%LOCAL_REPO_PATH%\.git" (
+    echo Local repository not found. Cloning from %REPO_URL%...
+    git clone %REPO_URL% "%LOCAL_REPO_PATH%"
+    if errorlevel 1 (
+        echo Failed to clone repository. Please check your internet connection and Git installation.
+        goto :error_exit
+    )
+    echo Repository cloned successfully.
+) else (
+    echo Local repository found. Fetching updates...
+    cd "%LOCAL_REPO_PATH%"
+    git fetch origin
+    if errorlevel 1 (
+        echo Failed to fetch updates. Please check your internet connection.
+        REM Continue, as the app can still run with local version
+    ) else (
+        REM Check if local is behind remote (main or master branch)
+        git rev-parse @ > .git\local_commit.txt
+        git rev-parse @{u} > .gitemote_commit.txt
+        fc .git\local_commit.txt .gitemote_commit.txt > nul
+        if errorlevel 1 (
+            echo Update available. Pulling changes...
+            git pull origin
+            if errorlevel 1 (
+                echo Failed to pull updates. You might need to resolve conflicts manually.
+            ) else (
+                echo Application updated successfully.
+            )
+        ) else (
+            echo Application is up to date.
+        )
+        del .git\local_commit.txt .gitemote_commit.txt 2>nul
+        cd ..
+    )
+)
+
+REM --- 6. Run the application ---
+echo Starting General Purpose Agent...
+%PYTHON_EXE% "%LOCAL_REPO_PATH%\main.py"
+
+echo Application finished.
+goto :end
+
+:error_exit
+echo An error occurred during setup. Please check the messages above.
+:end
+pause
+endlocal

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# --- Configuration ---
+PYTHON_CMD="python3"
+PIP_CMD="pip3"
+REPO_URL="https://github.com/onlyzerosonce/SigmaOne"
+LOCAL_REPO_PATH="." # Assuming script is run from the repo root
+OLLAMA_API_ENDPOINT="http://localhost:11434"
+REQUIRED_PACKAGES="PyQt5 GitPython requests"
+
+# --- Helper function to check if a command exists ---
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# --- 1. Check for Python ---
+echo "Checking for Python 3..."
+if ! command_exists $PYTHON_CMD; then
+    echo "Python 3 is not found. Please install Python 3."
+    # Attempt to guide based on common package managers
+    if command_exists apt-get; then
+        echo "You might be able to install it with: sudo apt-get update && sudo apt-get install python3 python3-pip"
+    elif command_exists yum; then
+        echo "You might be able to install it with: sudo yum install python3 python3-pip"
+    elif command_exists brew; then
+        echo "You might be able to install it with: brew install python3"
+    else
+        echo "Please visit https://www.python.org/downloads/"
+    fi
+    exit 1
+fi
+echo "Python 3 found."
+
+# --- 2. Check for Pip ---
+echo "Checking for Pip 3..."
+if ! command_exists $PIP_CMD; then
+    echo "Pip 3 is not found."
+    echo "Attempting to install pip for Python 3..."
+    if command_exists apt-get; then
+        sudo apt-get update && sudo apt-get install python3-pip -y
+    elif command_exists yum; then
+        sudo yum install python3-pip -y
+    else
+        echo "Please ensure pip is installed for Python 3 (e.g., often installed with python3 or via 'python3 -m ensurepip --upgrade')."
+    fi
+    if ! command_exists $PIP_CMD; then
+        echo "Failed to install Pip 3. Please install it manually."
+        exit 1
+    fi
+fi
+echo "Pip 3 found."
+
+# --- 3. Install/Upgrade Python dependencies ---
+echo "Checking and installing Python packages: $REQUIRED_PACKAGES..."
+for package in $REQUIRED_PACKAGES; do
+    echo "Installing/updating $package..."
+    if ! $PIP_CMD install --upgrade "$package"; then
+        echo "Failed to install $package. Please check your Python/pip setup and internet connection."
+        exit 1
+    fi
+done
+echo "All required Python packages are installed/updated."
+
+# --- 4. Check for Ollama ---
+echo "Checking for Ollama service at $OLLAMA_API_ENDPOINT..."
+# Using curl to check. -s for silent, -f for fail fast (non-2xx is an error), -o /dev/null to discard output.
+if curl -s -f -o /dev/null "$OLLAMA_API_ENDPOINT/api/tags"; then # Check a valid Ollama endpoint
+    echo "Ollama service detected."
+else
+    echo "Ollama service not detected or not responding at $OLLAMA_API_ENDPOINT."
+    echo "Please ensure Ollama is installed and running."
+    echo "You can download Ollama from https://ollama.com/"
+    echo "The agent may not function correctly without Ollama."
+    echo "Continuing to start the agent, but chatbot features will likely be disabled."
+    echo ""
+fi
+
+# --- 5. Git Repository Update ---
+echo "Checking for application updates..."
+if [ ! -d "$LOCAL_REPO_PATH/.git" ]; then
+    echo "Local repository not found. Cloning from $REPO_URL..."
+    if ! git clone "$REPO_URL" "$LOCAL_REPO_PATH"; then
+        echo "Failed to clone repository. Please check your internet connection and Git installation."
+        exit 1
+    fi
+    echo "Repository cloned successfully."
+    cd "$LOCAL_REPO_PATH" || exit 1 # Enter the repo dir
+else
+    echo "Local repository found. Fetching updates..."
+    cd "$LOCAL_REPO_PATH" || exit 1 # Enter the repo dir
+    if ! git fetch origin; then
+        echo "Failed to fetch updates. Please check your internet connection. Continuing with local version."
+    else
+        LOCAL_COMMIT=$(git rev-parse @)
+        REMOTE_COMMIT=$(git rev-parse @{u}) # Fails if branch not tracking remote, or no remote
+
+        if [ "$LOCAL_COMMIT" != "$REMOTE_COMMIT" ]; then
+            echo "Update available. Pulling changes..."
+            if ! git pull origin; then
+                echo "Failed to pull updates. You might need to resolve conflicts manually."
+            else
+                echo "Application updated successfully."
+            fi
+        else
+            echo "Application is up to date."
+        fi
+    fi
+fi
+
+# --- 6. Run the application ---
+echo "Starting General Purpose Agent..."
+$PYTHON_CMD main.py
+
+echo "Application finished."
+# No pause needed for .sh typically, window stays open.
+exit 0


### PR DESCRIPTION
This major update refactors the agent to use Ollama for chatbot functionality and introduces unified startup scripts (`start.bat` for Windows, `start.sh` for Linux/macOS).

Key changes:
- `main.py` now communicates with a local Ollama instance via its API (using the `requests` library) instead of using Hugging Face `transformers` and `torch` directly.
- New `start.bat` and `start.sh` scripts handle:
    - Checking and installing Python dependencies (PyQt5, GitPython, requests).
    - Verifying Ollama service accessibility and guiding you if Ollama is not running.
    - Automatically checking for and pulling updates for me from my Git repository.
    - Launching the `main.py` application.
- Old `install.bat` and `install.sh` scripts have been removed.
- `README.md` has been extensively updated to reflect these new prerequisites (Python, Git, your installed Ollama), the functionality of the start scripts, and the change in chatbot backend.

I now rely on you having Ollama installed and running with a suitable model pulled.